### PR TITLE
Shared libraries for C FFI should use cdylib instead of dylib

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ authors = [ "herman@hermanradtke.com" ]
 
 [lib]
 name = "score"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 libc = "0.1.7"


### PR DESCRIPTION
See https://doc.rust-lang.org/reference/linkage.html for details